### PR TITLE
Fixed broken links on quickstart page

### DIFF
--- a/content/guides/quickstart.mdx
+++ b/content/guides/quickstart.mdx
@@ -89,8 +89,8 @@ That's it! You've successfully set up your MarbleCMS workspace and created your 
 Now you're ready to connect your content to your frontend. Check out our integration guides to get started.
 
 <CardGroup>
-  <Card title="Next.js Integration" href="/integrations/nextjs" icon="react"></Card>
-  <Card title="Astro Integration" href="/integrations/astro" icon="stars"></Card>
+  <Card title="Next.js Integration" href="/content/guides/integrations/nextjs" icon="react"></Card>
+  <Card title="Astro Integration" href="/content/guides/integrations/astro" icon="stars"></Card>
 </CardGroup>
 </Step>
 </Steps>


### PR DESCRIPTION
On https://docs.marblecms.com/content/guides/quickstart the links used on step 5 for Integration guides were wrong so Mintlify keeps redirecting me to https://docs.marblecms.com/content/guides/introduction when I click the Astro and Nextjs integration cards:
<img width="783" height="427" alt="image" src="https://github.com/user-attachments/assets/6437708a-4d21-4192-9189-4b73cfa5829e" />

This PR fixes this issue by adding correct links to those cards.