### PR TITLE
docs(integrations): Update TanStack Start guide to use `.inputValidator()`.

### DIFF
--- a/guides/integrations/tanstack.mdx
+++ b/guides/integrations/tanstack.mdx
@@ -84,7 +84,7 @@ export const getTags = createServerFn().handler(async () => {
 });
 
 export const getSinglePost = createServerFn()
-  .validator(z.string())
+  .inputValidator(z.string())
   .handler(async ({ data: slug }) => {
     try {
       const raw = await fetch(`${url}/${key}/posts/${slug}`);


### PR DESCRIPTION
Replace deprecated `.validator(z.string())` with `.inputValidator(z.string())` in the TanStack Start integration guide's `getSinglePost` example (`guides/integrations/tanstack.mdx:87`) to align with the current API.

Reference: https://tanstack.com/start/latest/docs/framework/react/guide/server-functions#:~:text=%27%20%7D)%0A%20%20.-,inputValidator,-((data%3A