### PR TITLE
fix: ResponseExample and RequestExample

### DIFF
--- a/api/endpoint/authors.mdx
+++ b/api/endpoint/authors.mdx
@@ -18,7 +18,7 @@ fetch("https://api.marblecms.com/v1/cm6ytuq9x0000i803v0isidst/authors")
 </RequestExample>
 
 <ResponseExample>
-```json
+```json Response
 {
   "authors": [
     {

--- a/api/endpoint/categories.mdx
+++ b/api/endpoint/categories.mdx
@@ -18,7 +18,7 @@ fetch("https://api.marblecms.com/v1/cm6ytuq9x0000i803v0isidst/categories")
 </RequestExample>
 
 <ResponseExample>
-```json
+```json Response
 {
   "categories": [
     {

--- a/api/endpoint/post.mdx
+++ b/api/endpoint/post.mdx
@@ -31,7 +31,7 @@ fetch(
 </RequestExample>
 
 <ResponseExample>
-```json
+```json Response
 {
   "post": {
     "id": "clt92n38p000108l48zkj41an",

--- a/api/endpoint/posts.mdx
+++ b/api/endpoint/posts.mdx
@@ -4,7 +4,6 @@ description: "Retrieves a paginated list of posts in a workspace."
 ---
 
 <RequestExample>
-<CodeGroup>
 ```bash cURL
 curl "https://api.marblecms.com/v1/cm6ytuq9x0000i803v0isidst/posts"
 ```
@@ -22,11 +21,10 @@ import requests
 response = requests.get("https://api.marblecms.com/v1/cm6ytuq9x0000i803v0isidst/posts")
 print(response.json())
 ```
-</CodeGroup>
 </RequestExample>
 
 <ResponseExample>
-```json
+```json Response
 {
   "posts": [
     {

--- a/api/endpoint/tags.mdx
+++ b/api/endpoint/tags.mdx
@@ -18,7 +18,7 @@ fetch("https://api.marblecms.com/v1/cm6ytuq9x0000i803v0isidst/tags")
 </RequestExample>
 
 <ResponseExample>
-```json
+```json Response
 {
   "tags": [
     {


### PR DESCRIPTION
- `RequestExample` works like `CodeGroup` so you don't need to add `CodeGroup` inside `RequestExample` (but please double check this on your side as well)
- added titles inline, so your docs work properly, but will investigate on our side how this is even possible
- banner will be fixed soon, i know the issue, fixing it